### PR TITLE
Remove Keymaps category

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"url": "https://github.com/prashantkoshta/heroku-command-vscode.git"
 	},
 	"categories": [
-		"Keymaps", "Languages", "Other"
+		"Languages", "Other"
 	],
     "engines": {
         "vscode": "^1.5.0"


### PR DESCRIPTION
Cool extension. We intended Keymaps to be for extensions that are providing a large set of keyboard shortcuts from another product, rather than adding keyboard shortcuts. Apologize the purpose of keymaps category was not clearer. 